### PR TITLE
Added RABBITMQ_ERLANG_COOKIE env var

### DIFF
--- a/rabbitmq/rabbitmq-deployment.yaml
+++ b/rabbitmq/rabbitmq-deployment.yaml
@@ -26,6 +26,9 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        env:
+        - name: RABBITMQ_ERLANG_COOKIE
+          value: "mycookie"
         volumeMounts:
         - mountPath: /var/lib/rabbitmq
           name: rabbitmq-data

--- a/rabbitmq/rabbitmq-pvc.yaml
+++ b/rabbitmq/rabbitmq-pvc.yaml
@@ -5,6 +5,7 @@ metadata:
     volume.beta.kubernetes.io/storage-class: default
   name: rabbitmq-data
 spec:
+  storageClassName: openebs-standard
   accessModes:
   - ReadWriteOnce
   resources:


### PR DESCRIPTION
Environment:  ICP 2.1.0.1 (Ubuntu 16.04)

Encountering thrashing rabbitmq deployment with errors of "/var/lib/rabbitmq/.erlang.cookie must be accessible by owner only" in the pod logs.  By adding the env attribute that specs out an environment variable of RABBITMQ_ERLANG_COOKIE with a default dummy value of "mycookie" ... the pod thrashing has stopped.

Should also consider updating the README to explain that this mycookie value is merely a default starter value that should be changed if used in any non-demo deployment.